### PR TITLE
Add Agent Brain to RAG Long-text and Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Simulation of Conversational Intelligence in Chat, EACL 2024 [[Paper](https://ar
 ## RAG Long-text and Memory
 
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. VSCode extension + CLI + MCP server. Free.
+- [Agent Brain](https://github.com/kaderosio/agent-brain) - 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Built with FastAPI, PostgreSQL/pgvector. Self-hostable.
 
 **HippoRAG: Neurobiologically Inspired Long-Term Memory for Large Language Models** \
 *Bernal Jiménez Gutiérrez, Yiheng Shu, Yu Gu, Michihiro Yasunaga, Yu Su* \


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the RAG Long-text and Memory section.

Agent Brain is an open-source 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Built with FastAPI, PostgreSQL/pgvector. Self-hostable via Docker.