### PR TITLE
Add Not Human Search to retrieval tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Simulation of Conversational Intelligence in Chat, EACL 2024 [[Paper](https://ar
 
 ## RAG Search
 
+- [Not Human Search](https://nothumansearch.ai) - Search engine and MCP server for discovering AI-native tools. 8,600+ sites indexed with agentic capability scoring. Useful for RAG pipelines that need to discover and integrate AI tools.
+
 ## RAG Long-text and Memory
 
 **ComoRAG: A Cognitive-Inspired Memory-Organized RAG for Stateful Long Narrative Reasoning** \                    


### PR DESCRIPTION
## Summary

- Adds [Not Human Search](https://nothumansearch.ai) to the **RAG Search** section
- Not Human Search is a search engine and MCP server for discovering AI-native tools, with 8,600+ sites indexed and agentic capability scoring
- Useful for RAG pipelines that need to discover and integrate AI tools at build time

## Details

Not Human Search provides:
- Full-text search over 8,600+ AI-native tool sites
- MCP (Model Context Protocol) server endpoint for agent integration
- Agentic capability scoring for each indexed site
- OpenAPI spec and llms.txt for easy integration into RAG workflows