### PR TITLE
Add Statewave to RAG Long-text and Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ AAAI 2026 - Aug 2025 [[paper](https://arxiv.org/abs/2508.10419)] [[GitHub](https
 
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. VSCode extension + CLI + MCP server. Free.
 - [Agent Brain](https://github.com/kaderosio/agent-brain) - 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Built with FastAPI, PostgreSQL/pgvector. Self-hostable.
+- [Statewave](https://github.com/smaramwbc/statewave) - Open-source memory runtime for AI agents. Compiles events into deterministic, provenance-tagged context bundles instead of query-time retrieval. Apache-2.0, self-hostable on Postgres + pgvector.
 
 **HippoRAG: Neurobiologically Inspired Long-Term Memory for Large Language Models** \
 *Bernal Jiménez Gutiérrez, Yiheng Shu, Yu Gu, Michihiro Yasunaga, Yu Su* \


### PR DESCRIPTION
## Add Statewave to RAG Long-text and Memory

Statewave is an open-source memory runtime that takes the
"compile-not-retrieve" position on long-context — instead of
query-time retrieval over a vector store, it compiles a
deterministic, provenance-tagged context bundle per conversation.
Recompiles when the underlying conversation changes.

This is conceptually adjacent to the **HippoRAG** and **ComoRAG**
papers already in this section (memory architectures for long-context
reasoning) — but landed as a production OSS runtime rather than a
paper implementation.

### Why it fits this section

- Self-hostable on Postgres + pgvector
- Apache-2.0 across server + SDKs (Python + TypeScript)
- 9 official connectors (GitHub, Slack, Notion, Discord, Zendesk
  family, Gmail, n8n, Zapier) + MCP server

### Placement

Inserted as a third tool entry after `Agent Brain`, keeping the
existing paper entries (`HippoRAG`, `Understanding Retrieval
Augmentation…`) in their current order below.