### PR TITLE
Add Superhighway to RAG Search — live web search API for RAG pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Simulation of Conversational Intelligence in Chat, EACL 2024 [[Paper](https://ar
 ## RAG Search
 
 - [Not Human Search](https://nothumansearch.ai) - Search engine and MCP server for discovering AI-native tools. 8,600+ sites indexed with agentic capability scoring. Useful for RAG pipelines that need to discover and integrate AI tools.
+- [Superhighway](https://superhighway.walls.sh) - Web search API for RAG pipelines and AI agents — live web search, news, images, scrape, and one-call deep research (search + read top pages). Pay per call via x402/USDC (no signup) or free API key. MCP-compatible: `npx -y superhighway-mcp`.
 
 ## RAG Long-text and Memory
 


### PR DESCRIPTION
## What

Adds [Superhighway](https://superhighway.walls.sh) to the **RAG Search** section alongside Not Human Search.

Superhighway is a web search API built for RAG pipelines and AI agents:
- **5 tools**: `/search`, `/news`, `/images`, `/scrape`, `/research` (search + read top pages in one call)
- **Payment**: per-call in USDC via x402 protocol (no signup, no API key needed for agents) or a free API key (1k calls/month)
- **MCP-compatible**: `npx -y superhighway-mcp` loads all five tools into any MCP-aware framework

For RAG specifically, `/research?q=...` handles the search + scrape step in a single call — useful for pipelines that need fresh web content without managing two separate calls.

Framework integrations are covered in guides at https://superhighway.walls.sh/guides (LangChain, LlamaIndex, Haystack, Pydantic AI, AutoGen, and more).