### PR TITLE
Add PieKBS to Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We strongly encourage the researchers that want to promote their fantastic work 
 - [guardian-agent-prompts](https://github.com/milkomida77/guardian-agent-prompts) - 49 production-tested AI agent system prompts for Claude Code multi-agent orchestration with retrieval-augmented generation patterns. MIT licensed.
 - [CCHub](https://github.com/Moresl/cchub) - A desktop control panel for the Claude Code / Codex / Gemini CLI ecosystem. Manage MCP servers, config profiles, agent skills, CLAUDE.md, hooks, and workflow templates from a single Tauri app (Windows / macOS / Linux).
 - [ChunkTuner](https://github.com/shantanu-deshmukh/chunktuner) - Open-source Python/CLI/MCP tooling to benchmark chunking strategies for RAG and recommend configurations using retrieval metrics (optional RAGAS).
+- [PieKBS](https://github.com/pieteams/piekbs) - Local-first knowledge search engine for agents with FTS5 full-text search and graph-based document expansion via citation/support/wiki links. Pure Go, no embedding required.
 
 ## Workshops and Tutorials
 - [Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain) - Self-evolving AI coding intelligence with infinite memory (TurboQuant), genetic algorithm self-evolution, predictive bug detection, PageRank knowledge graphs, swarm intelligence, and adversarial defense.


### PR DESCRIPTION
Hi, thanks for maintaining this list - it's a great resource.

I'd like to add **PieKBS** to the Resources section.

- Repo: https://github.com/pieteams/piekbs
- License: MIT
- Docs: https://pieteams.github.io/piekbs/

PieKBS is a local-first knowledge search engine for agents. It distills raw documents into a structured Markdown wiki and exposes MCP tools for search and deep-reading. Key features:

- **FTS5 full-text search** with BM25 scoring (no embedding required)
- **Graph-based document expansion** via citation/support/wiki/related_to links
- **Multi-hop tag expansion** for discovering related documents through shared keywords
- **MCP protocol support** for seamless integration with AI agents
- **Pure Go binary** with no external dependencies

Happy to adjust the wording or placement if needed.