### PR TITLE
Add ScholarCopilot (COLM 2025) to RAG Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ arXiv - Oct 2023. [[Paper](https://arxiv.org/abs/2310.16146v1)]
 *Sheshera Mysore, Zhuoran Lu, Mengting Wan, Longqi Yang, Steve Menezes, Tina Baghaee, Emmanuel Barajas Gonzalez, Jennifer Neville, Tara Safavi* \
 arXiv - Nov 2023. [[Paper](https://arxiv.org/abs/2311.09180)] 
 
+**ScholarCopilot: Training Large Language Models for Academic Writing with Accurate Citations** \
+*Yubo Wang, Xueguang Ma, Ping Nie, Huaye Zeng, Zhiheng Lyu, Yuxuan Zhang, Benjamin Schneider, Yi Lu, Xiang Yue, Wenhu Chen* \
+COLM 2025 - Apr 2025 [[Paper](https://arxiv.org/abs/2504.00824)] [[Code](https://github.com/TIGER-AI-Lab/ScholarCopilot)]
+
 
 
 ## RAG for Missing Modalities


### PR DESCRIPTION
Adds ScholarCopilot to RAG Application, alongside PEARL / Clinfo.ai.

ScholarCopilot (COLM 2025, arXiv:2504.00824)'s method is retrieval-augmented generation for academic writing: a learned [RET] token triggers mid-generation citation retrieval from a 500K-paper corpus, with joint retrieval + generation training. Reports 40.1% top-1 citation-retrieval accuracy.

- Paper: https://arxiv.org/abs/2504.00824
- Code: https://github.com/TIGER-AI-Lab/ScholarCopilot

Entry follows the section's paper-block format. Thanks!