### PR TITLE
RAG Evaluation: add verbatim-citation-gate (deterministic pre-filter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ EMNLP 2023 - Oct 2023 [[Paper](https://arxiv.org/abs/2310.06816?ref=upstract.com
 *Michael Günther, Jackmin Ong, Isabelle Mohr, Alaeddine Abdessalem, Tanguy Abel, Mohammad Kalim Akram, Susana Guzman, Georgios Mastrapas, Saba Sturua, Bo Wang, Maximilian Werk, Nan Wang, Han Xiao* \
 arXiv - Oct 2023. [[Paper](https://arxiv.org/abs/2310.19923)][[Model](https://huggingface.co/jinaai/jina-embeddings-v2-small-en)] 
 
+**verbatim-citation-gate: Deterministic Verbatim Check for LLM Citations** \n*Palo Alto AI Research Lab* [[Github](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)] - Checks whether a quoted span actually appears in the document the model cited, before any judge model runs. Zero model calls, no API keys, framework-agnostic; Unicode-aware normalization so non-Latin quotes are checked, not silently dropped. Returns found / misattributed / not_found and fails closed on malformed input. It verifies verbatim overlap only: it does not judge whether the cited passage supports the claim. MIT-licensed.
+
 **EmbedGuard: Cross-Layer Detection and Provenance Attestation for Adversarial Embedding Attacks in RAG Systems** \
 *Neeraj Patty* \
 IJCESEN 2026. [[Paper](https://doi.org/10.22399/ijcesen.4869)][[Github](https://github.com/neerazz/embedguard)] - MIT-licensed defense operating across embedding generation, retrieval, and generation layers with cryptographic provenance attestation.


### PR DESCRIPTION
Self-submission: verbatim-citation-gate is maintained by the submitting author.

Adds one entry to **RAG Evaluation**.

**What it does.** Before any judge model runs, it checks whether a quoted span literally appears in the document the model cited. Returns `found` / `misattributed` / `not_found`, and fails closed on malformed input rather than raising. Zero model calls, no API keys, no framework dependency.

**Why it belongs in RAG Evaluation.** Most entries here evaluate a pipeline after generation with a model in the loop. This one is the cheap deterministic pre-filter: fabricated quotes are rejected at zero cost, so the judge only sees what survived.

**The boundary, stated plainly.** It verifies verbatim overlap only. It does **not** judge whether the cited passage supports the claim, and it does not detect paraphrased fabrication. Anything beyond literal overlap is out of scope by design.

**Verification as of 2026-08-06:**
- License: MIT
- Latest commit: 2026-08-05
- Tests: 17 passing on Python 3.9/3.11/3.13 across Linux, macOS and Windows (CI runs on every push and weekly)
- Duplicate check: README contains no prior `verbatim-citation-gate` name or URL
- Non-Latin coverage: normalization is Unicode-aware, with regression tests in Cyrillic, CJK and accented Latin. This came from an outside contributor who caught that an ASCII-only filter was silently passing fabricated non-English quotes.

Happy to move it to a different section or shorten the description if you prefer.